### PR TITLE
Fix Token methods & Add null skip token in parser.

### DIFF
--- a/src/main/java/lexer/Token.java
+++ b/src/main/java/lexer/Token.java
@@ -59,6 +59,7 @@ public class Token {
     }
 
     public boolean isNot(TokenType tokenType) {
-        return tokenType == this.type;
+        return tokenType != this.type;
     }
+    public boolean is(TokenType tokenType) { return tokenType == this.type; }
 }

--- a/src/main/java/parser/Parser.java
+++ b/src/main/java/parser/Parser.java
@@ -44,13 +44,16 @@ public class Parser {
     /// Helpers
 
     void skipTill(TokenType tokenType) {  // For simple error recovery instead of having chain of errors
+        if (tokenType == null) return;
 
         while (currentToken.isNot(tokenType) && currentToken.isNot(TokenType.EOF))
             // Todo: Switch on tokens;
             consume();
-
     }
 
+     void skipTill() {
+        skipTill(null);
+     }
     boolean consume() {
         if (idx < lexer.getTokens().size()) {
             skippedToken = currentToken;
@@ -103,6 +106,24 @@ public class Parser {
         }
     }
 
+    // used for symbolic token `:, ), {, }, (, "," ,`
+    boolean parseToken(TokenType tokenType, TokenType skipToToken) {
+        if (currentToken.is(tokenType)) {
+            consume();
+            return false;
+        }
+        // logError;
+
+        // recover
+        skipTill(skipToToken);
+        if (tokenType == skipToToken && currentToken.is(skipToToken))
+            consume();
+        return true;
+    }
+
+    boolean parseToken(TokenType tokenType) {
+        return parseToken(tokenType, null);
+    }
     private boolean isExpr(TokenType tokenType) {
         return tokenType == TokenType.NUMBER_LITERAL || tokenType == TokenType.TRUE
                || tokenType == TokenType.FALSE || tokenType == TokenType.IDENTIFIER;


### PR DESCRIPTION
Error recovery for parsing is important, Helps to cut the chain of error
you might get. Example: `func void foo() { .... ;   var x: int = 10;`
here after seeing semicolon we expect } r_brace, However , There's no
`}` and currentToken will still be `;` then the parser will not
terminate as no runtime exception used. Move on to var but currentToken
is still `;` as a result we will have chain of error as parseEat will
output so many error til we break and terminate.
SkipTill will give us good start to recover from parsing error and
determine when to terminate as appropriate, However, To implement so
there should be change in almost all parsing implementaion methods and
technieques , And that's a high risk.
This acts like Doc.